### PR TITLE
fix: Image is no longer based on zenika

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Uses [puppeteer](https://developers.google.com/web/tools/puppeteer) and
 Written in [typescript](https://www.typescriptlang.org/)
 compiled by [webpack](https://webpack.js.org/) and
 dependencies managed by [yarn 3](https://yarnpkg.com/).
-Docker file is based on [`zenika/alpine-chrome`](https://github.com/Zenika/alpine-chrome)
-image but it can be replaced with any other having headless chrome and [node.js](https://nodejs.org/) in it.
+Docker file is inspired by [`zenika/alpine-chrome`](https://github.com/Zenika/alpine-chrome).
 
 ⚠️ Disclaimer: chrome is run with `--no-sandbox` flag meaning it should **NOT** be run as a public service.
 It's only meant to be run as a microservice in your private network where you control **what** you are printing.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:prod": "env-cmd -f .env.prod webpack",
     "build:dev": "env-cmd -f .env.dev webpack",
     "lint": "eslint ./",
-    "test": "jest --colors"
+    "test": "jest --colors --runInBand"
   },
   "dependencies": {
     "@sentry/node": "^7.19.0",


### PR DESCRIPTION
Fix Readme: image is no longer based on `zenika/alpine-chrome`, only inspired by it, but is standalone.